### PR TITLE
Add subnet to main Internal IP display.

### DIFF
--- a/app/src/main/java/com/aaronjwood/portauthority/activity/MainActivity.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/activity/MainActivity.java
@@ -270,12 +270,23 @@ public class MainActivity extends AppCompatActivity implements MainAsyncResponse
                 mHandler.postDelayed(this, TIMER_INTERVAL);
             }
         }, 0);
-        this.internalIp.setText(this.wifi.getInternalWifiIpAddress());
+        this.getInternalIp();
         this.getExternalIp();
         this.ssid.setText(this.wifi.getSSID());
         this.bssid.setText(this.wifi.getBSSID());
     }
 
+    /**
+     * Wrapper method for getting the internal wireless IP address.
+     * This gets the netmask, counts the bits set (subnet size),
+     * then prints it along side the IP.
+     */
+    private void getInternalIp(){
+        int netmask = this.wifi.getInternalWifiSubnet();
+        int count = Integer.bitCount(netmask);
+        String InternalIpWithSubnet = this.wifi.getInternalWifiIpAddress() + "/" + Integer.toString(count);
+        this.internalIp.setText(InternalIpWithSubnet);
+    }
     /**
      * Wrapper for getting the external IP address
      * We can control whether or not to do this based on the user's preference

--- a/app/src/main/java/com/aaronjwood/portauthority/network/Wireless.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/network/Wireless.java
@@ -3,9 +3,11 @@ package com.aaronjwood.portauthority.network;
 import android.app.Activity;
 import android.content.Context;
 import android.net.ConnectivityManager;
+import android.net.DhcpInfo;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
+import android.text.format.Formatter;
 
 import com.aaronjwood.portauthority.async.GetExternalIpAsyncTask;
 import com.aaronjwood.portauthority.response.MainAsyncResponse;
@@ -17,6 +19,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.ByteOrder;
+import java.text.Normalizer;
 import java.util.Enumeration;
 
 public class Wireless {
@@ -143,6 +146,19 @@ public class Wireless {
         } catch (UnknownHostException ex) {
             return null;
         }
+    }
+
+    /*
+     * Gets the Wifi Manager DHCP information and returns the Netmask of the
+     * internal Wifi Network as an int
+     *
+     * @return Internal Wifi Subnet Netmask
+     */
+    public int getInternalWifiSubnet() {
+        // ToDo: Make sure this works with static DHCP reservations.
+        WifiManager wifiManager = this.getWifiManager();
+        DhcpInfo dhcpInfo = wifiManager.getDhcpInfo();
+        return dhcpInfo.netmask;
     }
 
     /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -169,7 +169,7 @@
                 android:id="@+id/hostList"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="1"
+                android:layout_weight="0.71"
                 android:cacheColorHint="@color/black" />
 
             <Button

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -169,7 +169,7 @@
                 android:id="@+id/hostList"
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
-                android:layout_weight="0.71"
+                android:layout_weight="1"
                 android:cacheColorHint="@color/black" />
 
             <Button


### PR DESCRIPTION
Add getInternalWifiSubnet() method that uses the Wifi Manager class to grab DHCP info and returns the subnet netmask.

Add wrapper method getInternalIP() in order to construct the subnet string appropriately for display on the main screen.