### PR TITLE
Clear list of open ports found in previous search

### DIFF
--- a/app/src/main/java/com/aaronjwood/portauthority/activity/HostActivity.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/activity/HostActivity.java
@@ -193,6 +193,7 @@ public abstract class HostActivity extends AppCompatActivity implements HostAsyn
                 UserPreference.savePortRangeHigh(activity, stopPort);
 
                 ports.clear();
+                adapter.notifyDataSetChanged();
 
                 scanProgressDialog = new ProgressDialog(activity, R.style.DialogTheme);
                 scanProgressDialog.setCancelable(false);

--- a/app/src/main/java/com/aaronjwood/portauthority/activity/LanHostActivity.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/activity/LanHostActivity.java
@@ -105,6 +105,7 @@ public final class LanHostActivity extends HostActivity {
                 }
 
                 ports.clear();
+                adapter.notifyDataSetChanged();
 
                 int startPort = 1;
                 int stopPort = 1024;

--- a/app/src/main/java/com/aaronjwood/portauthority/activity/WanHostActivity.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/activity/WanHostActivity.java
@@ -58,6 +58,7 @@ public final class WanHostActivity extends HostActivity {
             @Override
             public void onClick(View v) {
                 ports.clear();
+                adapter.notifyDataSetChanged();
 
                 int startPort = 1;
                 int stopPort = 1024;


### PR DESCRIPTION
The List object containing the ports is cleared for a new search, but the changes are not updated on the portList TextView.  A subsequent search that returns no open ports keeps the previous list of ports, and clicking on one of these ports crashes the app.

Another thing I noticed was that these changes were done inside three onClick methods that have very similar code.  Perhaps you could create a new method inside HostActivity or a subclass of View.OnClickListener to reduce code repetition.