### PR TITLE
Port mDNS hostname resolution from 'Angry IP Scanner' + Fix NetBIOS hostname resolution + Add API 31 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: android
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 android:
   components:
     - build-tools-30.0.3
-    - android-29
+    - android-31
 
 env:
   global:
    - secure: "em+bEb3nWLV7f+Dt4y9/OH2Lpf6mscT9E52kXhSEm/PiFpTtzlx7BgHGlpsYVwsMf0e7x2AdF/yzq4c7ugoMqWmFXMthgFUKcLTXqW/IeARGz3smMXnyScRoaFElDm0Q33fxiqDlU7UVA4j1FysR5GqTU10MasJgGpoyTthRQvra0LU8zwI4IMiASfa8Tij5LclsbaTpcgB4TdXtBmbpKQAUzjvV/ZfLsYQ950C0rbVKk9T1xtc8d5BTbggwHWbMMqGn6RFvSCQioeI/Q6Daak6zDglUY+JE/1BnzlGzoba9C7TLZV4+TQkmB5kc6FtKqSXycjwJSKm3wQFYOzJrLMPqMtlmaAeTEs5yBIYtIIAiID+hbeUKvWTpoUxwUYz7s7XLikJRdxe7iBlhdy3qv+FdGOJjV9g/xeSVXISvXzcKp2sNdU+FABBBDAA2CKWrZOXuzPAh8iYxLnt649hQFAw99ylkn75+LpJgq7gRUO87Fde0Zw3vYhLIS8UH3OBtggV1yrYHuKXWUyfkiA/xcm+NSFgIXJzGvYlOZWS+uZvXeh7wJz5CF0t3m6emBoqX6JAXQ/t9SgwGX8lwbLPK3HiYBnTMEDxb6qpIiYa8E8tfudA1YNyeszG8mZtiErJf9YleagACuASwPFsLb8Bg9BNJX5X89+VrbzPbncZD9Tc="
 
 before_install:
-  - yes | sdkmanager "platforms;android-29"
+  - yes | sdkmanager "platforms;android-31"
+  - yes | sdkmanager "ndk;21.4.7075529"
   - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 addons:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,16 +15,21 @@ sonarqube {
 
 android {
     viewBinding.enabled = true
-    compileSdkVersion 29
+    compileSdkVersion 31
     buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 63
         versionName "2.4.1"
         applicationId "com.aaronjwood.portauthority"
         setProperty("archivesBaseName", "PortAuthority-$versionName")
+        externalNativeBuild {
+            ndkBuild {
+                cppFlags ''
+            }
+        }
     }
 
     compileOptions {
@@ -59,18 +64,22 @@ android {
             dimension "main"
         }
     }
-
-    lintOptions {
+    lint {
         abortOnError false
     }
+    externalNativeBuild {
+        ndkBuild {
+            path file('src/main/c/Android.mk')
+        }
+    }
+
 }
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.squareup.okhttp3:okhttp:3.12.9' // Anything past 3.12.x will break our Android 4 support!
-    implementation 'jcifs:jcifs:1.3.17'
-    implementation 'org.minidns:minidns-hla:0.3.2'
+    implementation 'org.minidns:minidns-hla:1.0.2'
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         <activity
             android:name=".activity.MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme">
+            android:theme="@style/AppTheme"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/c/Android.mk
+++ b/app/src/main/c/Android.mk
@@ -1,0 +1,6 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := ipneigh
+LOCAL_SRC_FILES := dnet_ntop.c libnetlink.c ipneigh.c ll_map.c ipx_ntop.c mpls_ntop.c
+include $(BUILD_SHARED_LIBRARY)

--- a/app/src/main/c/dnet_ntop.c
+++ b/app/src/main/c/dnet_ntop.c
@@ -1,0 +1,100 @@
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+
+#include "utils.h"
+
+static __inline__ u_int16_t dn_ntohs(u_int16_t addr)
+{
+	union {
+		u_int8_t byte[2];
+		u_int16_t word;
+	} u;
+
+	u.word = addr;
+	return ((u_int16_t)u.byte[0]) | (((u_int16_t)u.byte[1]) << 8);
+}
+
+static __inline__ int do_digit(char *str, u_int16_t *addr, u_int16_t scale, size_t *pos, size_t len, int *started)
+{
+	u_int16_t tmp = *addr / scale;
+
+	if (*pos == len)
+		return 1;
+
+	if (((tmp) > 0) || *started || (scale == 1)) {
+		*str = tmp + '0';
+		*started = 1;
+		(*pos)++;
+		*addr -= (tmp * scale);
+	}
+
+	return 0;
+}
+
+
+static const char *dnet_ntop1(const struct dn_naddr *dna, char *str, size_t len)
+{
+	u_int16_t addr, area;
+	size_t pos = 0;
+	int started = 0;
+
+	memcpy(&addr, dna->a_addr, sizeof(addr));
+	addr = dn_ntohs(addr);
+	area = addr >> 10;
+
+	if (dna->a_len != 2)
+		return NULL;
+
+	addr &= 0x03ff;
+
+	if (len == 0)
+		return str;
+
+	if (do_digit(str + pos, &area, 10, &pos, len, &started))
+		return str;
+
+	if (do_digit(str + pos, &area, 1, &pos, len, &started))
+		return str;
+
+	if (pos == len)
+		return str;
+
+	*(str + pos) = '.';
+	pos++;
+	started = 0;
+
+	if (do_digit(str + pos, &addr, 1000, &pos, len, &started))
+		return str;
+
+	if (do_digit(str + pos, &addr, 100, &pos, len, &started))
+		return str;
+
+	if (do_digit(str + pos, &addr, 10, &pos, len, &started))
+		return str;
+
+	if (do_digit(str + pos, &addr, 1, &pos, len, &started))
+		return str;
+
+	if (pos == len)
+		return str;
+
+	*(str + pos) = 0;
+
+	return str;
+}
+
+
+const char *dnet_ntop(int af, const void *addr, char *str, size_t len)
+{
+	switch(af) {
+		case AF_DECnet:
+			errno = 0;
+			return dnet_ntop1((struct dn_naddr *)addr, str, len);
+		default:
+			errno = EAFNOSUPPORT;
+	}
+
+	return NULL;
+}

--- a/app/src/main/c/ipneigh.c
+++ b/app/src/main/c/ipneigh.c
@@ -1,0 +1,389 @@
+/*
+ * ipneigh.c		"ip neigh".
+ *
+ *		This program is free software; you can redistribute it and/or
+ *		modify it under the terms of the GNU General Public License
+ *		as published by the Free Software Foundation; either version
+ *		2 of the License, or (at your option) any later version.
+ *
+ * Authors:	Alexey Kuznetsov, <kuznet@ms2.inr.ac.ru>
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <syslog.h>
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+
+#include <jni.h>
+
+#include "libnetlink.h"
+#include "list.h"
+#include "ll_map.h"
+#include "utils.h"
+
+// just to remove warning
+int print_neigh(const struct sockaddr_nl *who, struct nlmsghdr *n, void *arg);
+
+// from ll_addr.c
+const char *ll_addr_n2a(const unsigned char *addr, int alen, int type, char *buf, int blen)
+{
+	int i;
+	int l;
+
+	if (alen == 4 &&
+	    (type == ARPHRD_TUNNEL || type == ARPHRD_SIT || type == ARPHRD_IPGRE)) {
+		return inet_ntop(AF_INET, addr, buf, blen);
+	}
+	if (alen == 16 && type == ARPHRD_TUNNEL6) {
+		return inet_ntop(AF_INET6, addr, buf, blen);
+	}
+	snprintf(buf, blen, "%02x", addr[0]);
+	for (i = 1, l = 2; i < alen && l < blen; i++, l += 3)
+		snprintf(buf + l, blen - l, ":%02x", addr[i]);
+	return buf;
+}
+
+// from utils.c
+int get_user_hz(void)
+{
+	return sysconf(_SC_CLK_TCK);
+}
+const char *rt_addr_n2a_r(int af, int len,
+			  const void *addr, char *buf, int buflen)
+{
+	switch (af) {
+	case AF_INET:
+	case AF_INET6:
+		return inet_ntop(af, addr, buf, buflen);
+#ifndef ANDROID
+	case AF_MPLS:
+		return mpls_ntop(af, addr, buf, buflen);
+	case AF_IPX:
+		return ipx_ntop(af, addr, buf, buflen);
+	case AF_DECnet:
+	{
+		struct dn_naddr dna = { 2, { 0, 0, } };
+
+		memcpy(dna.a_addr, addr, 2);
+		return dnet_ntop(af, &dna, buf, buflen);
+	}
+#endif
+	case AF_PACKET:
+		return ll_addr_n2a(addr, len, ARPHRD_VOID, buf, buflen);
+	default:
+		return "???";
+	}
+}
+
+const char *format_host_r(int af, int len, const void *addr,
+			char *buf, int buflen)
+{
+#ifdef RESOLVE_HOSTNAMES
+	if (resolve_hosts) {
+		const char *n;
+
+		len = len <= 0 ? af_byte_len(af) : len;
+
+		if (len > 0 &&
+		    (n = resolve_address(addr, len, af)) != NULL)
+			return n;
+	}
+#endif
+	return rt_addr_n2a_r(af, len, addr, buf, buflen);
+}
+
+const char *format_host(int af, int len, const void *addr)
+{
+	static char buf[256];
+
+	return format_host_r(af, len, addr, buf, 256);
+}
+
+int inet_addr_match(const inet_prefix *a, const inet_prefix *b, int bits)
+{
+	const __u32 *a1 = a->data;
+	const __u32 *a2 = b->data;
+	int words = bits >> 0x05;
+
+	bits &= 0x1f;
+
+	if (words)
+		if (memcmp(a1, a2, words << 2))
+			return -1;
+
+	if (bits) {
+		__u32 w1, w2;
+		__u32 mask;
+
+		w1 = a1[words];
+		w2 = a2[words];
+
+		mask = htonl((0xffffffff) << (0x20 - bits));
+
+		if ((w1 ^ w2) & mask)
+			return 1;
+	}
+
+	return 0;
+}
+
+// from ip.c
+struct rtnl_handle rth = { .fd = -1 };
+
+// default ipneight.c
+static struct
+{
+	int family;
+	int index;
+	int state;
+	int unused_only;
+	inet_prefix pfx;
+	int flushed;
+	char *flushb;
+	int flushp;
+	int flushe;
+	int master;
+} filter;
+
+static int flush_update(void)
+{
+
+	/*
+	 * Note that the kernel may delete multiple addresses for one
+	 * delete request (e.g. if ipv4 address promotion is disabled).
+	 * Since a flush operation is really a series of delete requests
+	 * its possible that we may request an address delete that has
+	 * already been done by the kernel. Therefore, ignore EADDRNOTAVAIL
+	 * errors returned from a flush request
+	 */
+	if ((rtnl_send_check(&rth, filter.flushb, filter.flushp) < 0) &&
+	    (errno != EADDRNOTAVAIL)) {
+		perror("Failed to send flush request");
+		return -1;
+	}
+	filter.flushp = 0;
+	return 0;
+}
+
+int print_neigh(const struct sockaddr_nl *who, struct nlmsghdr *n, void *arg)
+{
+	FILE *fp = (FILE *)arg;
+	struct ndmsg *r = NLMSG_DATA(n);
+	int len = n->nlmsg_len;
+	struct rtattr *tb[NDA_MAX+1];
+	static int logit = 1;
+	static int show_stats = 0;
+
+	if (n->nlmsg_type != RTM_NEWNEIGH && n->nlmsg_type != RTM_DELNEIGH &&
+	    n->nlmsg_type != RTM_GETNEIGH) {
+		fprintf(stderr, "Not RTM_NEWNEIGH: %08x %08x %08x\n",
+			n->nlmsg_len, n->nlmsg_type, n->nlmsg_flags);
+
+		return 0;
+	}
+	len -= NLMSG_LENGTH(sizeof(*r));
+	if (len < 0) {
+		fprintf(stderr, "BUG: wrong nlmsg len %d\n", len);
+		return -1;
+	}
+
+	if (filter.flushb && n->nlmsg_type != RTM_NEWNEIGH)
+		return 0;
+
+	if (filter.family && filter.family != r->ndm_family)
+		return 0;
+	if (filter.index && filter.index != r->ndm_ifindex)
+		return 0;
+	if (!(filter.state&r->ndm_state) &&
+	    !(r->ndm_flags & NTF_PROXY) &&
+	    (r->ndm_state || !(filter.state&0x100)) &&
+	     (r->ndm_family != AF_DECnet))
+		return 0;
+
+	if (filter.master && !(n->nlmsg_flags & NLM_F_DUMP_FILTERED)) {
+		if (logit) {
+			logit = 0;
+			fprintf(fp,
+				"\nWARNING: Kernel does not support filtering by master device\n\n");
+		}
+	}
+
+	parse_rtattr(tb, NDA_MAX, NDA_RTA(r), n->nlmsg_len - NLMSG_LENGTH(sizeof(*r)));
+
+	if (tb[NDA_DST]) {
+		if (filter.pfx.family) {
+			inet_prefix dst = { .family = r->ndm_family };
+
+			memcpy(&dst.data, RTA_DATA(tb[NDA_DST]), RTA_PAYLOAD(tb[NDA_DST]));
+			if (inet_addr_match(&dst, &filter.pfx, filter.pfx.bitlen))
+				return 0;
+		}
+	}
+	if (filter.unused_only && tb[NDA_CACHEINFO]) {
+		struct nda_cacheinfo *ci = RTA_DATA(tb[NDA_CACHEINFO]);
+
+		if (ci->ndm_refcnt)
+			return 0;
+	}
+
+	if (filter.flushb) {
+		struct nlmsghdr *fn;
+
+		if (NLMSG_ALIGN(filter.flushp) + n->nlmsg_len > filter.flushe) {
+			if (flush_update())
+				return -1;
+		}
+		fn = (struct nlmsghdr *)(filter.flushb + NLMSG_ALIGN(filter.flushp));
+		memcpy(fn, n, n->nlmsg_len);
+		fn->nlmsg_type = RTM_DELNEIGH;
+		fn->nlmsg_flags = NLM_F_REQUEST;
+		fn->nlmsg_seq = ++rth.seq;
+		filter.flushp = (((char *)fn) + n->nlmsg_len) - filter.flushb;
+		filter.flushed++;
+		if (show_stats < 2)
+			return 0;
+	}
+
+	if (n->nlmsg_type == RTM_DELNEIGH)
+		fprintf(fp, "Deleted ");
+	else if (n->nlmsg_type == RTM_GETNEIGH)
+		fprintf(fp, "miss ");
+	if (tb[NDA_DST]) {
+		fprintf(fp, "%s ",
+			format_host_rta(r->ndm_family, tb[NDA_DST]));
+	}
+	if (!filter.index && r->ndm_ifindex)
+		fprintf(fp, "dev %s ", ll_index_to_name(r->ndm_ifindex));
+	if (tb[NDA_LLADDR]) {
+		SPRINT_BUF(b1);
+		fprintf(fp, "lladdr %s", ll_addr_n2a(RTA_DATA(tb[NDA_LLADDR]),
+					      RTA_PAYLOAD(tb[NDA_LLADDR]),
+					      ll_index_to_type(r->ndm_ifindex),
+					      b1, sizeof(b1)));
+	}
+	if (r->ndm_flags & NTF_ROUTER) {
+		fprintf(fp, " router");
+	}
+	if (r->ndm_flags & NTF_PROXY) {
+		fprintf(fp, " proxy");
+	}
+	if (tb[NDA_CACHEINFO] && show_stats) {
+		struct nda_cacheinfo *ci = RTA_DATA(tb[NDA_CACHEINFO]);
+		int hz = get_user_hz();
+
+		if (ci->ndm_refcnt)
+			printf(" ref %d", ci->ndm_refcnt);
+		fprintf(fp, " used %d/%d/%d", ci->ndm_used/hz,
+		       ci->ndm_confirmed/hz, ci->ndm_updated/hz);
+	}
+
+	if (tb[NDA_PROBES] && show_stats) {
+		__u32 p = rta_getattr_u32(tb[NDA_PROBES]);
+
+		fprintf(fp, " probes %u", p);
+	}
+
+	if (r->ndm_state) {
+		int nud = r->ndm_state;
+
+		fprintf(fp, " ");
+
+#define PRINT_FLAG(f) if (nud & NUD_##f) { \
+	nud &= ~NUD_##f; fprintf(fp, #f "%s", nud ? "," : ""); }
+		PRINT_FLAG(INCOMPLETE);
+		PRINT_FLAG(REACHABLE);
+		PRINT_FLAG(STALE);
+		PRINT_FLAG(DELAY);
+		PRINT_FLAG(PROBE);
+		PRINT_FLAG(FAILED);
+		PRINT_FLAG(NOARP);
+		PRINT_FLAG(PERMANENT);
+#undef PRINT_FLAG
+	}
+	fprintf(fp, "\n");
+
+	fflush(fp);
+	return 0;
+}
+
+void ipneigh_reset_filter(int ifindex)
+{
+	memset(&filter, 0, sizeof(filter));
+	filter.state = ~0;
+	filter.index = ifindex;
+}
+
+static int do_show_or_flush(int argc, char **argv, int flush, FILE *mypipe)
+{
+	struct {
+		struct nlmsghdr	n;
+		struct ndmsg		ndm;
+		char			buf[256];
+	} req = {
+		.n.nlmsg_type = RTM_GETNEIGH,
+		.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ndmsg)),
+	};
+	char *filter_dev = NULL;
+	static int preferred_family = AF_UNSPEC;
+	ipneigh_reset_filter(0);
+	if (!filter.family)
+		filter.family = preferred_family;
+	if (flush) {
+		if (argc <= 0) {
+			fprintf(stderr, "Flush requires arguments.\n");
+			return -1;
+		}
+		filter.state = ~(NUD_PERMANENT|NUD_NOARP);
+	} else
+		filter.state = 0xFF & ~NUD_NOARP;
+
+	// RTM_GETLINK forbidden by Android API 30
+	//ll_init_map(&rth);
+	if (filter_dev) {
+		if ((filter.index = ll_name_to_index(filter_dev)) == 0) {
+			fprintf(stderr, "Cannot find device \"%s\"\n", filter_dev);
+			return -1;
+		}
+		addattr32(&req.n, sizeof(req), NDA_IFINDEX, filter.index);
+	}
+	req.ndm.ndm_family = filter.family;
+	if (rtnl_dump_request_n(&rth, &req.n) < 0) {
+		perror("Cannot send dump request");
+		exit(1);
+	}
+	if (rtnl_dump_filter(&rth, print_neigh, mypipe) < 0) {
+		fprintf(stderr, "Dump terminated\n");
+		exit(1);
+	}
+	return 0;
+}
+
+int Java_com_aaronjwood_portauthority_async_ScanHostsAsyncTask_nativeIPNeigh(JNIEnv* env,
+                                                  jobject thiz,
+												  jint fileDescriptor) {
+
+	FILE *mypipe = fdopen(fileDescriptor, "w");
+	if (mypipe == NULL) {
+		perror("Cannot fdopen");
+		exit(EXIT_FAILURE);
+	}
+
+	if (rtnl_open(&rth, 0) < 0)
+		exit(1);
+
+	int res = do_show_or_flush(0, NULL, 0, mypipe);
+
+	rtnl_close(&rth);
+	fclose(mypipe);
+
+	return res;
+}

--- a/app/src/main/c/ipx_ntop.c
+++ b/app/src/main/c/ipx_ntop.c
@@ -1,0 +1,71 @@
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <stddef.h>
+
+#include "utils.h"
+
+static __inline__ int do_digit(char *str, u_int32_t addr, u_int32_t scale, size_t *pos, size_t len)
+{
+	u_int32_t tmp = addr >> (scale * 4);
+
+	if (*pos == len)
+		return 1;
+
+	tmp &= 0x0f;
+	if (tmp > 9)
+		*str = tmp + 'A' - 10;
+	else
+		*str = tmp + '0';
+	(*pos)++;
+
+	return 0;
+}
+
+static const char *ipx_ntop1(const struct ipx_addr *addr, char *str, size_t len)
+{
+	int i;
+	size_t pos = 0;
+
+	if (len == 0)
+		return str;
+
+	for(i = 7; i >= 0; i--)
+		if (do_digit(str + pos, ntohl(addr->ipx_net), i, &pos, len))
+			return str;
+
+	if (pos == len)
+		return str;
+
+	*(str + pos) = '.';
+	pos++;
+
+	for(i = 0; i < 6; i++) {
+		if (do_digit(str + pos, addr->ipx_node[i], 1, &pos, len))
+			return str;
+		if (do_digit(str + pos, addr->ipx_node[i], 0, &pos, len))
+			return str;
+	}
+
+	if (pos == len)
+		return str;
+
+	*(str + pos) = 0;
+
+	return str;
+}
+
+
+const char *ipx_ntop(int af, const void *addr, char *str, size_t len)
+{
+	switch(af) {
+		case AF_IPX:
+			errno = 0;
+			return ipx_ntop1((struct ipx_addr *)addr, str, len);
+		default:
+			errno = EAFNOSUPPORT;
+	}
+
+	return NULL;
+}

--- a/app/src/main/c/libnetlink.c
+++ b/app/src/main/c/libnetlink.c
@@ -1,0 +1,385 @@
+/*
+ * libnetlink.c	RTnetlink service routines.
+ *
+ *		This program is free software; you can redistribute it and/or
+ *		modify it under the terms of the GNU General Public License
+ *		as published by the Free Software Foundation; either version
+ *		2 of the License, or (at your option) any later version.
+ *
+ * Authors:	Alexey Kuznetsov, <kuznet@ms2.inr.ac.ru>
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <syslog.h>
+#include <fcntl.h>
+#include <net/if_arp.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/uio.h>
+
+#include "libnetlink.h"
+
+#ifndef SOL_NETLINK
+#define SOL_NETLINK 270
+#endif
+
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+int rcvbuf = 1024 * 1024;
+
+/* No extended error ack without libmnl */
+static int nl_dump_ext_err(const struct nlmsghdr *nlh, nl_ext_ack_fn_t errfn)
+{
+	return 0;
+}
+
+void rtnl_close(struct rtnl_handle *rth)
+{
+	if (rth->fd >= 0) {
+		close(rth->fd);
+		rth->fd = -1;
+	}
+}
+
+int rtnl_open_byproto(struct rtnl_handle *rth, unsigned int subscriptions,
+		      int protocol)
+{
+	socklen_t addr_len;
+	int sndbuf = 32768;
+	int one = 1;
+
+	memset(rth, 0, sizeof(*rth));
+
+	rth->proto = protocol;
+	rth->fd = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, protocol);
+	if (rth->fd < 0) {
+		perror("Cannot open netlink socket");
+		return -1;
+	}
+
+	if (setsockopt(rth->fd, SOL_SOCKET, SO_SNDBUF,
+		       &sndbuf, sizeof(sndbuf)) < 0) {
+		perror("SO_SNDBUF");
+		return -1;
+	}
+
+	if (setsockopt(rth->fd, SOL_SOCKET, SO_RCVBUF,
+		       &rcvbuf, sizeof(rcvbuf)) < 0) {
+		perror("SO_RCVBUF");
+		return -1;
+	}
+
+	/* Older kernels may no support extended ACK reporting */
+	setsockopt(rth->fd, SOL_NETLINK, NETLINK_EXT_ACK,
+		   &one, sizeof(one));
+
+	memset(&rth->local, 0, sizeof(rth->local));
+	rth->local.nl_family = AF_NETLINK;
+	rth->local.nl_groups = subscriptions;
+
+	/** Not required for our use case, and forbidden by Android API 30
+	if (bind(rth->fd, (struct sockaddr *)&rth->local,
+		 sizeof(rth->local)) < 0) {
+		perror("Cannot bind netlink socket");
+		return -1;
+	}
+	**/
+	addr_len = sizeof(rth->local);
+	if (getsockname(rth->fd, (struct sockaddr *)&rth->local,
+			&addr_len) < 0) {
+		perror("Cannot getsockname");
+		return -1;
+	}
+	if (addr_len != sizeof(rth->local)) {
+		fprintf(stderr, "Wrong address length %d\n", addr_len);
+		return -1;
+	}
+	if (rth->local.nl_family != AF_NETLINK) {
+		fprintf(stderr, "Wrong address family %d\n",
+			rth->local.nl_family);
+		return -1;
+	}
+	rth->seq = time(NULL);
+	return 0;
+}
+
+int rtnl_open(struct rtnl_handle *rth, unsigned int subscriptions)
+{
+	return rtnl_open_byproto(rth, subscriptions, NETLINK_ROUTE);
+}
+
+int rtnl_send_check(struct rtnl_handle *rth, const void *buf, int len)
+{
+	struct nlmsghdr *h;
+	int status;
+	char resp[1024];
+
+	status = send(rth->fd, buf, len, 0);
+	if (status < 0)
+		return status;
+
+	/* Check for immediate errors */
+	status = recv(rth->fd, resp, sizeof(resp), MSG_DONTWAIT|MSG_PEEK);
+	if (status < 0) {
+		if (errno == EAGAIN)
+			return 0;
+		return -1;
+	}
+
+	for (h = (struct nlmsghdr *)resp; NLMSG_OK(h, status);
+	     h = NLMSG_NEXT(h, status)) {
+		if (h->nlmsg_type == NLMSG_ERROR) {
+			struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(h);
+
+			if (h->nlmsg_len < NLMSG_LENGTH(sizeof(struct nlmsgerr)))
+				fprintf(stderr, "ERROR truncated\n");
+			else
+				errno = -err->error;
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+int rtnl_dump_request_n(struct rtnl_handle *rth, struct nlmsghdr *n)
+{
+	struct sockaddr_nl nladdr = { .nl_family = AF_NETLINK };
+	struct iovec iov = {
+		.iov_base = n,
+		.iov_len = n->nlmsg_len
+	};
+	struct msghdr msg = {
+		.msg_name = &nladdr,
+		.msg_namelen = sizeof(nladdr),
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+	};
+
+	n->nlmsg_flags = NLM_F_DUMP|NLM_F_REQUEST;
+	n->nlmsg_pid = 0;
+	n->nlmsg_seq = rth->dump = ++rth->seq;
+
+	return sendmsg(rth->fd, &msg, 0);
+}
+
+static int rtnl_dump_done(struct nlmsghdr *h)
+{
+	int len = *(int *)NLMSG_DATA(h);
+
+	if (h->nlmsg_len < NLMSG_LENGTH(sizeof(int))) {
+		fprintf(stderr, "DONE truncated\n");
+		return -1;
+	}
+
+	if (len < 0) {
+		errno = -len;
+		switch (errno) {
+		case ENOENT:
+		case EOPNOTSUPP:
+			return -1;
+		case EMSGSIZE:
+			fprintf(stderr,
+				"Error: Buffer too small for object.\n");
+			break;
+		default:
+			perror("RTNETLINK answers");
+		}
+		return len;
+	}
+
+	return 0;
+}
+
+static void rtnl_dump_error(const struct rtnl_handle *rth,
+			    struct nlmsghdr *h)
+{
+
+	if (h->nlmsg_len < NLMSG_LENGTH(sizeof(struct nlmsgerr))) {
+		fprintf(stderr, "ERROR truncated\n");
+	} else {
+		const struct nlmsgerr *err = (struct nlmsgerr *)NLMSG_DATA(h);
+
+		errno = -err->error;
+		if (rth->proto == NETLINK_SOCK_DIAG &&
+		    (errno == ENOENT ||
+		     errno == EOPNOTSUPP))
+			return;
+
+		if (!(rth->flags & RTNL_HANDLE_F_SUPPRESS_NLERR))
+			perror("RTNETLINK answers");
+	}
+}
+
+int rtnl_dump_filter_l(struct rtnl_handle *rth,
+		       const struct rtnl_dump_filter_arg *arg)
+{
+	struct sockaddr_nl nladdr;
+	struct iovec iov;
+	struct msghdr msg = {
+		.msg_name = &nladdr,
+		.msg_namelen = sizeof(nladdr),
+		.msg_iov = &iov,
+		.msg_iovlen = 1,
+	};
+	char buf[32768];
+	int dump_intr = 0;
+
+	iov.iov_base = buf;
+	while (1) {
+		int status;
+		const struct rtnl_dump_filter_arg *a;
+		int found_done = 0;
+		int msglen = 0;
+
+		iov.iov_len = sizeof(buf);
+		status = recvmsg(rth->fd, &msg, 0);
+
+		if (status < 0) {
+			if (errno == EINTR || errno == EAGAIN)
+				continue;
+			fprintf(stderr, "netlink receive error %s (%d)\n",
+				strerror(errno), errno);
+			return -1;
+		}
+
+		if (status == 0) {
+			fprintf(stderr, "EOF on netlink\n");
+			return -1;
+		}
+
+		if (rth->dump_fp)
+			fwrite(buf, 1, NLMSG_ALIGN(status), rth->dump_fp);
+
+		for (a = arg; a->filter; a++) {
+			struct nlmsghdr *h = (struct nlmsghdr *)buf;
+
+			msglen = status;
+
+			while (NLMSG_OK(h, msglen)) {
+				int err = 0;
+
+				h->nlmsg_flags &= ~a->nc_flags;
+
+				if (nladdr.nl_pid != 0 ||
+				    //rth->local.nl_pid == 0 because we disabled binding
+				    //h->nlmsg_pid != rth->local.nl_pid ||
+				    h->nlmsg_seq != rth->dump)
+					goto skip_it;
+
+				if (h->nlmsg_flags & NLM_F_DUMP_INTR)
+					dump_intr = 1;
+
+				if (h->nlmsg_type == NLMSG_DONE) {
+					err = rtnl_dump_done(h);
+					if (err < 0)
+						return -1;
+
+					found_done = 1;
+					break; /* process next filter */
+				}
+
+				if (h->nlmsg_type == NLMSG_ERROR) {
+					rtnl_dump_error(rth, h);
+					return -1;
+				}
+
+				if (!rth->dump_fp) {
+					err = a->filter(&nladdr, h, a->arg1);
+					if (err < 0)
+						return err;
+				}
+
+skip_it:
+				h = NLMSG_NEXT(h, msglen);
+			}
+		}
+
+		if (found_done) {
+			if (dump_intr)
+				fprintf(stderr,
+					"Dump was interrupted and may be inconsistent.\n");
+			return 0;
+		}
+
+		if (msg.msg_flags & MSG_TRUNC) {
+			fprintf(stderr, "Message truncated\n");
+			continue;
+		}
+		if (msglen) {
+			fprintf(stderr, "!!!Remnant of size %d\n", msglen);
+			exit(1);
+		}
+	}
+}
+
+int rtnl_dump_filter_nc(struct rtnl_handle *rth,
+		     rtnl_filter_t filter,
+		     void *arg1, __u16 nc_flags)
+{
+	const struct rtnl_dump_filter_arg a[2] = {
+		{ .filter = filter, .arg1 = arg1, .nc_flags = nc_flags, },
+		{ .filter = NULL,   .arg1 = NULL, .nc_flags = 0, },
+	};
+
+	return rtnl_dump_filter_l(rth, a);
+}
+
+int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data)
+{
+	return addattr_l(n, maxlen, type, &data, sizeof(__u32));
+}
+
+int addattr_l(struct nlmsghdr *n, int maxlen, int type, const void *data,
+	      int alen)
+{
+	int len = RTA_LENGTH(alen);
+	struct rtattr *rta;
+
+	if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen) {
+		fprintf(stderr,
+			"addattr_l ERROR: message exceeded bound of %d\n",
+			maxlen);
+		return -1;
+	}
+	rta = NLMSG_TAIL(n);
+	rta->rta_type = type;
+	rta->rta_len = len;
+	if (alen)
+		memcpy(RTA_DATA(rta), data, alen);
+	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
+	return 0;
+}
+
+int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len)
+{
+	return parse_rtattr_flags(tb, max, rta, len, 0);
+}
+
+int parse_rtattr_flags(struct rtattr *tb[], int max, struct rtattr *rta,
+		       int len, unsigned short flags)
+{
+	unsigned short type;
+
+	memset(tb, 0, sizeof(struct rtattr *) * (max + 1));
+	while (RTA_OK(rta, len)) {
+		type = rta->rta_type & ~flags;
+		if ((type <= max) && (!tb[type]))
+			tb[type] = rta;
+		rta = RTA_NEXT(rta, len);
+	}
+	if (len)
+		fprintf(stderr, "!!!Deficit %d, rta_len=%d\n",
+			len, rta->rta_len);
+	return 0;
+}
+

--- a/app/src/main/c/libnetlink.h
+++ b/app/src/main/c/libnetlink.h
@@ -1,0 +1,179 @@
+#ifndef __LIBNETLINK_H__
+#define __LIBNETLINK_H__ 1
+
+#include <stdio.h>
+#include <string.h>
+#include <asm/types.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/if_link.h>
+#include <linux/if_addr.h>
+#include <linux/neighbour.h>
+#include <linux/netconf.h>
+#include <arpa/inet.h>
+
+struct rtnl_handle {
+	int			fd;
+	struct sockaddr_nl	local;
+	struct sockaddr_nl	peer;
+	__u32			seq;
+	__u32			dump;
+	int			proto;
+	FILE		       *dump_fp;
+#define RTNL_HANDLE_F_LISTEN_ALL_NSID		0x01
+#define RTNL_HANDLE_F_SUPPRESS_NLERR		0x02
+	int			flags;
+};
+
+struct nlmsg_list {
+	struct nlmsg_list *next;
+	struct nlmsghdr   h;
+};
+
+struct nlmsg_chain {
+	struct nlmsg_list *head;
+	struct nlmsg_list *tail;
+};
+
+extern int rcvbuf;
+
+int rtnl_open(struct rtnl_handle *rth, unsigned int subscriptions)
+	__attribute__((warn_unused_result));
+
+int rtnl_open_byproto(struct rtnl_handle *rth, unsigned int subscriptions,
+			     int protocol)
+	__attribute__((warn_unused_result));
+
+void rtnl_close(struct rtnl_handle *rth);
+
+typedef int (*req_filter_fn_t)(struct nlmsghdr *nlh, int reqlen);
+
+int rtnl_dump_request_n(struct rtnl_handle *rth, struct nlmsghdr *n)
+	__attribute__((warn_unused_result));
+
+struct rtnl_ctrl_data {
+	int	nsid;
+};
+
+typedef int (*rtnl_filter_t)(const struct sockaddr_nl *,
+			     struct nlmsghdr *n, void *);
+
+typedef int (*nl_ext_ack_fn_t)(const char *errmsg, uint32_t off,
+			       const struct nlmsghdr *inner_nlh);
+
+struct rtnl_dump_filter_arg {
+	rtnl_filter_t filter;
+	void *arg1;
+	__u16 nc_flags;
+};
+
+int rtnl_dump_filter_l(struct rtnl_handle *rth,
+			      const struct rtnl_dump_filter_arg *arg);
+int rtnl_dump_filter_nc(struct rtnl_handle *rth,
+			rtnl_filter_t filter,
+			void *arg, __u16 nc_flags);
+#define rtnl_dump_filter(rth, filter, arg) \
+	rtnl_dump_filter_nc(rth, filter, arg, 0)
+int rtnl_send_check(struct rtnl_handle *rth, const void *buf, int)
+	__attribute__((warn_unused_result));
+
+int addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data);
+int addattr_l(struct nlmsghdr *n, int maxlen, int type,
+	      const void *data, int alen);
+
+int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len);
+int parse_rtattr_flags(struct rtattr *tb[], int max, struct rtattr *rta,
+			      int len, unsigned short flags);
+
+#define RTA_TAIL(rta) \
+		((struct rtattr *) (((void *) (rta)) + \
+				    RTA_ALIGN((rta)->rta_len)))
+
+#define parse_rtattr_nested(tb, max, rta) \
+	(parse_rtattr((tb), (max), RTA_DATA(rta), RTA_PAYLOAD(rta)))
+
+static inline __u8 rta_getattr_u8(const struct rtattr *rta)
+{
+	return *(__u8 *)RTA_DATA(rta);
+}
+static inline __u16 rta_getattr_u16(const struct rtattr *rta)
+{
+	return *(__u16 *)RTA_DATA(rta);
+}
+static inline __be16 rta_getattr_be16(const struct rtattr *rta)
+{
+	return ntohs(rta_getattr_u16(rta));
+}
+static inline __u32 rta_getattr_u32(const struct rtattr *rta)
+{
+	return *(__u32 *)RTA_DATA(rta);
+}
+static inline __be32 rta_getattr_be32(const struct rtattr *rta)
+{
+	return ntohl(rta_getattr_u32(rta));
+}
+static inline __u64 rta_getattr_u64(const struct rtattr *rta)
+{
+	__u64 tmp;
+
+	memcpy(&tmp, RTA_DATA(rta), sizeof(__u64));
+	return tmp;
+}
+static inline const char *rta_getattr_str(const struct rtattr *rta)
+{
+	return (const char *)RTA_DATA(rta);
+}
+
+#define NLMSG_TAIL(nmsg) \
+	((struct rtattr *) (((void *) (nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
+
+#ifndef IFA_RTA
+#define IFA_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ifaddrmsg))))
+#endif
+#ifndef IFA_PAYLOAD
+#define IFA_PAYLOAD(n)	NLMSG_PAYLOAD(n, sizeof(struct ifaddrmsg))
+#endif
+
+#ifndef IFLA_RTA
+#define IFLA_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ifinfomsg))))
+#endif
+#ifndef IFLA_PAYLOAD
+#define IFLA_PAYLOAD(n)	NLMSG_PAYLOAD(n, sizeof(struct ifinfomsg))
+#endif
+
+#ifndef NDA_RTA
+#define NDA_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ndmsg))))
+#endif
+#ifndef NDA_PAYLOAD
+#define NDA_PAYLOAD(n)	NLMSG_PAYLOAD(n, sizeof(struct ndmsg))
+#endif
+
+#ifndef NDTA_RTA
+#define NDTA_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct ndtmsg))))
+#endif
+#ifndef NDTA_PAYLOAD
+#define NDTA_PAYLOAD(n) NLMSG_PAYLOAD(n, sizeof(struct ndtmsg))
+#endif
+
+#ifndef NETNS_RTA
+#define NETNS_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct rtgenmsg))))
+#endif
+#ifndef NETNS_PAYLOAD
+#define NETNS_PAYLOAD(n)	NLMSG_PAYLOAD(n, sizeof(struct rtgenmsg))
+#endif
+
+#ifndef IFLA_STATS_RTA
+#define IFLA_STATS_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct if_stats_msg))))
+#endif
+
+/* User defined nlmsg_type which is used mostly for logging netlink
+ * messages from dump file */
+#define NLMSG_TSTAMP	15
+
+#endif /* __LIBNETLINK_H__ */

--- a/app/src/main/c/list.h
+++ b/app/src/main/c/list.h
@@ -1,0 +1,128 @@
+#ifndef __LIST_H__
+#define __LIST_H__ 1
+/* List and hash list stuff from kernel */
+
+#include <stddef.h>
+
+#define container_of(ptr, type, member) ({			\
+	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
+	(type *)( (char *)__mptr - offsetof(type,member) );})
+
+struct list_head {
+	struct list_head *next, *prev;
+};
+
+static inline void INIT_LIST_HEAD(struct list_head *list)
+{
+	list->next = list;
+	list->prev = list;
+}
+
+static inline void __list_add(struct list_head *new,
+			      struct list_head *prev,
+			      struct list_head *next)
+{
+	next->prev = new;
+	new->next = next;
+	new->prev = prev;
+	prev->next = new;
+}
+
+static inline void list_add(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head, head->next);
+}
+
+static inline void list_add_tail(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head->prev, head);
+}
+
+static inline void __list_del(struct list_head *prev, struct list_head *next)
+{
+	next->prev = prev;
+	prev->next = next;
+}
+
+static inline void list_del(struct list_head *entry)
+{
+	__list_del(entry->prev, entry->next);
+}
+
+#define list_entry(ptr, type, member) \
+	container_of(ptr, type, member)
+
+#define list_first_entry(ptr, type, member) \
+	list_entry((ptr)->next, type, member)
+
+#define list_last_entry(ptr, type, member) \
+	list_entry((ptr)->prev, type, member)
+
+#define list_next_entry(pos, member) \
+	list_entry((pos)->member.next, typeof(*(pos)), member)
+
+#define list_prev_entry(pos, member) \
+	list_entry((pos)->member.prev, typeof(*(pos)), member)
+
+#define list_for_each_entry(pos, head, member)				\
+	for (pos = list_first_entry(head, typeof(*pos), member);	\
+	     &pos->member != (head);					\
+	     pos = list_next_entry(pos, member))
+
+#define list_for_each_entry_safe(pos, n, head, member)			\
+	for (pos = list_first_entry(head, typeof(*pos), member),	\
+		n = list_next_entry(pos, member);			\
+	     &pos->member != (head);					\
+	     pos = n, n = list_next_entry(n, member))
+
+#define list_for_each_entry_reverse(pos, head, member)			\
+	for (pos = list_last_entry(head, typeof(*pos), member);		\
+	     &pos->member != (head);					\
+	     pos = list_prev_entry(pos, member))
+
+struct hlist_head {
+	struct hlist_node *first;
+};
+
+struct hlist_node {
+	struct hlist_node *next, **pprev;
+};
+
+static inline void hlist_del(struct hlist_node *n)
+{
+	struct hlist_node *next = n->next;
+	struct hlist_node **pprev = n->pprev;
+	*pprev = next;
+	if (next)
+		next->pprev = pprev;
+}
+
+static inline void hlist_add_head(struct hlist_node *n, struct hlist_head *h)
+{
+	struct hlist_node *first = h->first;
+	n->next = first;
+	if (first)
+		first->pprev = &n->next;
+	h->first = n;
+	n->pprev = &h->first;
+}
+
+#define hlist_for_each(pos, head) \
+	for (pos = (head)->first; pos ; pos = pos->next)
+
+
+#define hlist_for_each_safe(pos, n, head) \
+	for (pos = (head)->first; pos && ({ n = pos->next; 1; }); \
+	     pos = n)
+
+#define hlist_entry_safe(ptr, type, member) \
+	({ typeof(ptr) ____ptr = (ptr); \
+	   ____ptr ? hlist_entry(____ptr, type, member) : NULL; \
+	})
+
+#define hlist_for_each_entry(pos, head, member)				\
+	for (pos = hlist_entry_safe((head)->first, typeof(*(pos)), member);\
+	     pos;							\
+	     pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
+
+#endif /* __LIST_H__ */

--- a/app/src/main/c/ll_map.c
+++ b/app/src/main/c/ll_map.c
@@ -1,0 +1,203 @@
+/*
+ * ll_map.c
+ *
+ *		This program is free software; you can redistribute it and/or
+ *		modify it under the terms of the GNU General Public License
+ *		as published by the Free Software Foundation; either version
+ *		2 of the License, or (at your option) any later version.
+ *
+ * Authors:	Alexey Kuznetsov, <kuznet@ms2.inr.ac.ru>
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <syslog.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <net/if.h>
+
+#include "libnetlink.h"
+#include "ll_map.h"
+#include "list.h"
+
+struct ll_cache {
+	struct hlist_node idx_hash;
+	struct hlist_node name_hash;
+	unsigned	flags;
+	unsigned 	index;
+	unsigned short	type;
+	char		name[];
+};
+
+#define IDXMAP_SIZE	1024
+static struct hlist_head idx_head[IDXMAP_SIZE];
+static struct hlist_head name_head[IDXMAP_SIZE];
+
+static struct ll_cache *ll_get_by_index(unsigned index)
+{
+	struct hlist_node *n;
+	unsigned h = index & (IDXMAP_SIZE - 1);
+
+	hlist_for_each(n, &idx_head[h]) {
+		struct ll_cache *im
+			= container_of(n, struct ll_cache, idx_hash);
+		if (im->index == index)
+			return im;
+	}
+
+	return NULL;
+}
+
+unsigned namehash(const char *str)
+{
+	unsigned hash = 5381;
+
+	while (*str)
+		hash = ((hash << 5) + hash) + *str++; /* hash * 33 + c */
+
+	return hash;
+}
+
+static struct ll_cache *ll_get_by_name(const char *name)
+{
+	struct hlist_node *n;
+	unsigned h = namehash(name) & (IDXMAP_SIZE - 1);
+
+	hlist_for_each(n, &name_head[h]) {
+		struct ll_cache *im
+			= container_of(n, struct ll_cache, name_hash);
+
+		if (strncmp(im->name, name, IFNAMSIZ) == 0)
+			return im;
+	}
+
+	return NULL;
+}
+
+int ll_remember_index(const struct sockaddr_nl *who,
+		      struct nlmsghdr *n, void *arg)
+{
+	unsigned int h;
+	const char *ifname;
+	struct ifinfomsg *ifi = NLMSG_DATA(n);
+	struct ll_cache *im;
+	struct rtattr *tb[IFLA_MAX+1];
+
+	if (n->nlmsg_type != RTM_NEWLINK && n->nlmsg_type != RTM_DELLINK)
+		return 0;
+
+	if (n->nlmsg_len < NLMSG_LENGTH(sizeof(*ifi)))
+		return -1;
+
+	im = ll_get_by_index(ifi->ifi_index);
+	if (n->nlmsg_type == RTM_DELLINK) {
+		if (im) {
+			hlist_del(&im->name_hash);
+			hlist_del(&im->idx_hash);
+			free(im);
+		}
+		return 0;
+	}
+
+	parse_rtattr(tb, IFLA_MAX, IFLA_RTA(ifi), IFLA_PAYLOAD(n));
+	ifname = rta_getattr_str(tb[IFLA_IFNAME]);
+	if (ifname == NULL)
+		return 0;
+
+	if (im) {
+		/* change to existing entry */
+		if (strcmp(im->name, ifname) != 0) {
+			hlist_del(&im->name_hash);
+			h = namehash(ifname) & (IDXMAP_SIZE - 1);
+			hlist_add_head(&im->name_hash, &name_head[h]);
+		}
+
+		im->flags = ifi->ifi_flags;
+		return 0;
+	}
+
+	im = malloc(sizeof(*im) + strlen(ifname) + 1);
+	if (im == NULL)
+		return 0;
+	im->index = ifi->ifi_index;
+	strcpy(im->name, ifname);
+	im->type = ifi->ifi_type;
+	im->flags = ifi->ifi_flags;
+
+	h = ifi->ifi_index & (IDXMAP_SIZE - 1);
+	hlist_add_head(&im->idx_hash, &idx_head[h]);
+
+	h = namehash(ifname) & (IDXMAP_SIZE - 1);
+	hlist_add_head(&im->name_hash, &name_head[h]);
+
+	return 0;
+}
+
+const char *ll_idx_n2a(unsigned idx, char *buf)
+{
+	const struct ll_cache *im;
+
+	if (idx == 0)
+		return "*";
+
+	im = ll_get_by_index(idx);
+	if (im)
+		return im->name;
+
+	if (if_indextoname(idx, buf) == NULL)
+		snprintf(buf, IFNAMSIZ, "if%d", idx);
+
+	return buf;
+}
+
+const char *ll_index_to_name(unsigned idx)
+{
+	static char nbuf[IFNAMSIZ];
+
+	return ll_idx_n2a(idx, nbuf);
+}
+
+int ll_index_to_type(unsigned idx)
+{
+	const struct ll_cache *im;
+
+	if (idx == 0)
+		return -1;
+
+	im = ll_get_by_index(idx);
+	return im ? im->type : -1;
+}
+
+int ll_index_to_flags(unsigned idx)
+{
+	const struct ll_cache *im;
+
+	if (idx == 0)
+		return 0;
+
+	im = ll_get_by_index(idx);
+	return im ? im->flags : -1;
+}
+
+unsigned ll_name_to_index(const char *name)
+{
+	const struct ll_cache *im;
+	unsigned idx;
+
+	if (name == NULL)
+		return 0;
+
+	im = ll_get_by_name(name);
+	if (im)
+		return im->index;
+
+	idx = if_nametoindex(name);
+	if (idx == 0)
+		sscanf(name, "if%u", &idx);
+	return idx;
+}
+

--- a/app/src/main/c/ll_map.h
+++ b/app/src/main/c/ll_map.h
@@ -1,0 +1,15 @@
+#ifndef __LL_MAP_H__
+#define __LL_MAP_H__ 1
+
+int ll_remember_index(const struct sockaddr_nl *who,
+		      struct nlmsghdr *n, void *arg);
+
+void ll_init_map(struct rtnl_handle *rth);
+unsigned ll_name_to_index(const char *name);
+const char *ll_index_to_name(unsigned idx);
+const char *ll_idx_n2a(unsigned idx, char *buf);
+int ll_index_to_type(unsigned idx);
+int ll_index_to_flags(unsigned idx);
+unsigned namehash(const char *str);
+
+#endif /* __LL_MAP_H__ */

--- a/app/src/main/c/mpls_ntop.c
+++ b/app/src/main/c/mpls_ntop.c
@@ -1,0 +1,50 @@
+#include <errno.h>
+#include <string.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <linux/mpls.h>
+
+#include "utils.h"
+
+static const char *mpls_ntop1(const struct mpls_label *addr, char *buf, size_t buflen)
+{
+	size_t destlen = buflen;
+	char *dest = buf;
+	int count = 0;
+
+	while (1) {
+		uint32_t entry = ntohl(addr[count++].entry);
+		uint32_t label = (entry & MPLS_LS_LABEL_MASK) >> MPLS_LS_LABEL_SHIFT;
+		int len = snprintf(dest, destlen, "%u", label);
+
+		if (len >= destlen)
+			break;
+
+		/* Is this the end? */
+		if (entry & MPLS_LS_S_MASK)
+			return buf;
+
+		dest += len;
+		destlen -= len;
+		if (destlen) {
+			*dest = '/';
+			dest++;
+			destlen--;
+		}
+	}
+	errno = -E2BIG;
+	return NULL;
+}
+
+const char *mpls_ntop(int af, const void *addr, char *buf, size_t buflen)
+{
+	switch(af) {
+	case AF_MPLS:
+		errno = 0;
+		return mpls_ntop1((struct mpls_label *)addr, buf, buflen);
+	default:
+		errno = EAFNOSUPPORT;
+	}
+
+	return NULL;
+}

--- a/app/src/main/c/utils.h
+++ b/app/src/main/c/utils.h
@@ -1,0 +1,65 @@
+#ifndef __UTILS_H__
+#define __UTILS_H__ 1
+
+#include <asm/types.h>
+#include <stdio.h>
+
+// from if.h
+//#define	IFNAMSIZ	16
+
+// Needed for Android build, why ?
+#define AF_MPLS   28
+
+// from if_arp.h
+#define ARPHRD_VOID	  0xFFFF	/* Void type, nothing is known */
+#define ARPHRD_TUNNEL	768		/* IPIP tunnel			*/
+#define ARPHRD_TUNNEL6	769		/* IP6IP6 tunnel       		*/
+#define ARPHRD_IPGRE	778		/* GRE over IP			*/
+#define ARPHRD_SIT	776		/* sit0 device - IPv6-in-IPv4	*/
+
+
+// from utils.h
+#define SPRINT_BSIZE 64
+#define SPRINT_BUF(x)	char x[SPRINT_BSIZE]
+#define format_host_rta(af, rta) \
+	format_host(af, RTA_PAYLOAD(rta), RTA_DATA(rta))
+#define DN_MAXADDL 20
+#define IPX_NODE_LEN 6
+
+struct ipx_addr {
+	u_int32_t ipx_net;
+	u_int8_t  ipx_node[IPX_NODE_LEN];
+};
+
+struct dn_naddr
+{
+        unsigned short          a_len;
+        unsigned char a_addr[DN_MAXADDL];
+};
+
+typedef struct
+{
+	__u16 flags;
+	__u16 bytelen;
+	__s16 bitlen;
+	/* These next two fields match rtvia */
+	__u16 family;
+	__u32 data[64];
+} inet_prefix;
+
+int get_hex(char c);
+int get_user_hz(void);
+const char *ipx_ntop(int af, const void *addr, char *str, size_t len);
+const char *dnet_ntop(int af, const void *addr, char *str, size_t len);
+const char *mpls_ntop(int af, const void *addr, char *buf, size_t buflen);
+int inet_addr_match(const inet_prefix *a, const inet_prefix *b, int bits);
+void ipneigh_reset_filter(int ifindex);
+const char *rt_addr_n2a_r(int af, int len, const void *addr,
+			       char *buf, int buflen);
+const char *format_host(int af, int len, const void *addr);
+const char *format_host_r(int af, int len, const void *addr,
+			       char *buf, int buflen);
+const char *ll_addr_n2a(const unsigned char *addr, int alen,
+			int type, char *buf, int blen);
+
+#endif /* __UTILS_H__ */

--- a/app/src/main/java/com/aaronjwood/portauthority/activity/MainActivity.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/activity/MainActivity.java
@@ -767,7 +767,9 @@ public final class MainActivity extends AppCompatActivity implements MainAsyncRe
     @Override
     public void processFinish(final Host h, final AtomicInteger i) {
         scanHandler.post(() -> {
-            hosts.add(h);
+            if (h != null) {
+                hosts.add(h);
+            }
             hostAdapter.sort((lhs, rhs) -> {
                 int leftIp = ByteBuffer.wrap(lhs.getAddress()).getInt();
                 int rightIp = ByteBuffer.wrap(rhs.getAddress()).getInt();

--- a/app/src/main/java/com/aaronjwood/portauthority/network/Host.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/network/Host.java
@@ -53,6 +53,9 @@ public class Host implements Serializable {
      * @param hostname Hostname for this host
      */
     public void setHostname(String hostname) {
+        if (hostname != null && hostname.isEmpty() && hostname.endsWith(".local")) {
+            hostname = hostname.substring(0, hostname.length() - 6);
+        }
         this.hostname = hostname;
 
     }

--- a/app/src/main/java/com/aaronjwood/portauthority/network/Wireless.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/network/Wireless.java
@@ -61,8 +61,10 @@ public class Wireless {
             throw new NoWifiInterface();
         }
 
-        // TODO: address this for Android 11 https://developer.android.com/training/articles/user-data-ids#mac-11-plus
         byte[] mac = iface.getHardwareAddress();
+        if (mac == null) {
+            return new String("Not available");
+        }
         StringBuilder buf = new StringBuilder();
         for (byte aMac : mac) {
             buf.append(String.format("%02x:", aMac));

--- a/app/src/main/java/com/aaronjwood/portauthority/utils/MDNSResolver.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/utils/MDNSResolver.java
@@ -1,0 +1,80 @@
+package com.aaronjwood.portauthority.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+
+public class MDNSResolver implements Closeable {
+	InetAddress mdnsIP = InetAddress.getByName("224.0.0.251");
+	private int mdnsPort = 5353;
+	MulticastSocket socket = new MulticastSocket();
+
+	public MDNSResolver(int timeout) throws IOException {
+		socket.setSoTimeout(timeout);
+		socket.setTimeToLive(1);
+		// TODO: iPhones respond only back to the multicast address and port 5353 provided requestId == 0
+		socket.joinGroup(mdnsIP);
+	}
+
+	void writeName(DataOutputStream out, String name) throws IOException {
+		int s = 0, e;
+		while ((e = name.indexOf('.', s)) != -1) {
+			out.writeByte(e - s);
+			out.write(name.substring(s, e).getBytes());
+			s = e + 1;
+		}
+		out.write(name.length() - s);
+		out.write(name.substring(s).getBytes());
+		out.writeByte(0);
+	}
+
+	String decodeName(byte[] data, int offset, int length) {
+		StringBuilder s = new StringBuilder(length);
+		for (int i = offset; i < offset + length; i++) {
+			byte len = data[i];
+			if (len == 0) break;
+			s.append(new String(data, i + 1, len)).append('.');
+			i += len;
+		}
+		s.setLength(s.length() - 1);
+		return s.toString();
+	}
+
+	byte[] dnsRequest(int id, String name) throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		DataOutputStream out = new DataOutputStream(baos);
+		out.writeShort(id);
+		out.write(new byte[] {0, 0, 0, 1, 0, 0, 0, 0, 0, 0});
+		writeName(out, name);
+		out.write(new byte[] {0, 0xc, 0, 1});
+		return baos.toByteArray();
+	}
+
+	String reverseName(byte[] addr) {
+		// note: only IPv4 is supported here
+		return (addr[3]&0xFF) + "." + (addr[2]&0xFF) + "." + (addr[1]&0xFF) + "." + (addr[0]&0xFF) + ".in-addr.arpa";
+	}
+
+	public String resolve(InetAddress ip) throws IOException {
+		byte[] addr = ip.getAddress();
+		int requestId = addr[2] * 0xFF + addr[3];
+		byte[] request = dnsRequest(requestId, reverseName(addr));
+		socket.send(new DatagramPacket(request, request.length, mdnsIP, mdnsPort));
+
+		DatagramPacket respPacket = new DatagramPacket(new byte[512], 512);
+		socket.receive(respPacket);
+		byte[] response = respPacket.getData();
+		if (response[0] != request[0] && response[1] != request[1]) return null;
+		int numQueries = response[5];
+		int offset = (numQueries == 0 ? 12 + reverseName(addr).length() : request.length) + 2 + 2 + 2 + 4 + 2;
+		return decodeName(response, offset, respPacket.getLength() - offset);
+	}
+
+	public void close() {
+		socket.close();
+	}
+}

--- a/app/src/main/java/com/aaronjwood/portauthority/utils/NetBIOSResolver.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/utils/NetBIOSResolver.java
@@ -1,0 +1,98 @@
+package com.aaronjwood.portauthority.utils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+
+public class NetBIOSResolver implements Closeable {
+	private static final int NETBIOS_UDP_PORT = 137;
+	private static final byte[] REQUEST_DATA = {(byte)0xA2, 0x48, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x43, 0x4b, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x00, 0x00, 0x21, 0x00, 0x01};
+
+	private static final int RESPONSE_TYPE_POS = 47;
+	private static final byte RESPONSE_TYPE_NBSTAT = 33;
+	private static final int RESPONSE_BASE_LEN = 57;
+	private static final int RESPONSE_NAME_LEN = 15;
+	private static final int RESPONSE_NAME_BLOCK_LEN = 18;
+
+	private static final int GROUP_NAME_FLAG = 128;
+	private static final int NAME_TYPE_DOMAIN = 0x00;
+	private static final int NAME_TYPE_MESSENGER = 0x03;
+
+	DatagramSocket socket = new DatagramSocket();
+
+	public NetBIOSResolver(int timeout) throws SocketException {
+		socket.setSoTimeout(timeout);
+	}
+
+	public String[] resolve(InetAddress ip) throws IOException {
+		socket.send(new DatagramPacket(REQUEST_DATA, REQUEST_DATA.length, ip, NETBIOS_UDP_PORT));
+
+		byte[] response = new byte[1024];
+		DatagramPacket responsePacket = new DatagramPacket(response, response.length);
+		socket.receive(responsePacket);
+
+		if (responsePacket.getLength() < RESPONSE_BASE_LEN || response[RESPONSE_TYPE_POS] != RESPONSE_TYPE_NBSTAT) {
+			return null; // response was too short - no names returned
+		}
+
+		int nameCount = response[RESPONSE_BASE_LEN - 1] & 0xFF;
+		if (responsePacket.getLength() < RESPONSE_BASE_LEN + RESPONSE_NAME_BLOCK_LEN * nameCount) {
+			return null; // data was truncated or something is wrong
+		}
+
+		return extractNames(response, nameCount);
+	}
+
+	static String[] extractNames(byte[] response, int nameCount) {
+		String computerName = nameCount > 0 ? name(response, 0) : null;
+
+		String groupName = null;
+		for (int i = 1; i < nameCount; i++) {
+			if (nameType(response, i) == NAME_TYPE_DOMAIN && (nameFlag(response, i) & GROUP_NAME_FLAG) > 0) {
+				groupName = name(response, i);
+				break;
+			}
+		}
+
+		String userName = null;
+		for (int i = nameCount - 1; i > 0; i--) {
+			if (nameType(response, i) == NAME_TYPE_MESSENGER) {
+				userName = name(response, i);
+				break;
+			}
+		}
+
+		String macAddress = String.format("%02X-%02X-%02X-%02X-%02X-%02X",
+				nameByte(response, nameCount, 0), nameByte(response, nameCount, 1),
+				nameByte(response, nameCount, 2), nameByte(response, nameCount, 3),
+				nameByte(response, nameCount, 4), nameByte(response, nameCount, 5));
+
+		return new String[] {computerName, userName, groupName, macAddress};
+	}
+
+	private static String name(byte[] response, int i) {
+		// as we have no idea in which encoding are the received names,
+		// assume that local default encoding matches the remote one (they are on the same LAN most probably)
+		return new String(response, RESPONSE_BASE_LEN + RESPONSE_NAME_BLOCK_LEN * i, RESPONSE_NAME_LEN).trim();
+	}
+
+	private static int nameByte(byte[] response, int i, int n) {
+		return response[RESPONSE_BASE_LEN + RESPONSE_NAME_BLOCK_LEN * i + n] & 0xFF;
+	}
+
+	private static int nameFlag(byte[] response, int i) {
+		return response[RESPONSE_BASE_LEN + RESPONSE_NAME_BLOCK_LEN * i + RESPONSE_NAME_LEN + 1] & 0xFF +
+				(response[RESPONSE_BASE_LEN + RESPONSE_NAME_BLOCK_LEN * i + RESPONSE_NAME_LEN + 2] & 0xFF) * 0xFF;
+	}
+
+	private static int nameType(byte[] response, int i) {
+		return response[RESPONSE_BASE_LEN + RESPONSE_NAME_BLOCK_LEN * i + RESPONSE_NAME_LEN] & 0xFF;
+	}
+
+	public void close() {
+		socket.close();
+	}
+}

--- a/app/src/main/res/values-fr/array.xml
+++ b/app/src/main/res/values-fr/array.xml
@@ -16,7 +16,7 @@
     </string-array>
     <string-array name="upperDrawer">
         <item>\u2601 Scanner l\'IP WAN</item>
-        <item>\u263c Reveiller l'appareil</item>
+        <item>\u263c Reveiller l\'appareil</item>
         <item>\u2194 Recherche DNS</item>
     </string-array>
     <string-array name="lowerDrawer">

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -38,7 +38,7 @@
     <string name="sortVendor">Par fournisseur MAC</string>
     <string name="copyHostname">Copier le nom d\'hôte</string>
     <string name="copyIp">Copier l\'IP</string>
-    <string name="copyMac">Copier l'adresse MAC</string>
+    <string name="copyMac">Copier l\'adresse MAC</string>
     <string name="getMacVendorFailed">Fournisseur MAC indisponible</string>
     <string name="failedOpenDb">Échec de l\'ouverture de la base de données</string>
     <string name="downloadingData">Téléchargement des données</string>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:7.1.1'
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
Hi 👋 

In this pull request I ported the mDNS hostname resolution from [Angry IP Scanner](https://github.com/angryip/ipscan) (also GPL licensed) and fixed the NetBIOS hostname resolution which wasn't working for workstations.

Few modification from upstream [MDNSResolver](https://github.com/angryip/ipscan/blob/master/src/net/azib/ipscan/util/MDNSResolver.java), first uncommenting `socket.joinGroup(mdnsIP);` which is working on Android and catch more hosts (was disabled because of macOS I guess) :

https://github.com/aaronjwood/PortAuthority/blob/4debcfa25a680e2e0e183bca9b95061ccc9a7a99/app/src/main/java/com/aaronjwood/portauthority/utils/MDNSResolver.java#L19-L20

And modify hostnames parsing accordingly, which change slightly : 

https://github.com/aaronjwood/PortAuthority/blob/4debcfa25a680e2e0e183bca9b95061ccc9a7a99/app/src/main/java/com/aaronjwood/portauthority/utils/MDNSResolver.java#L73

~~Regarding the changes to the NetBIOS hostname resolution, it now catches the `NETBIOS_WORKSTATION` name. The default behaviour isn't changed at all, as the `NETBIOS_FILE_SERVER` name is still used in priority if present.~~

Both the NetBIOS and mDNS hostname resolution now respects the Lan Socket Timeout setting, which is helpful on slow networks.

The changes in .xml strings are for Android Studio, which refuse to compile without these minor modifications. The rest of the code is commented, but feel free to ask any question!