### PR TITLE
Fix OUI & Ports data

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,10 @@ This means that modifications need to be done either on a new branch based off o
 This app does not track, collect, or share any data it comes across with anyone or anything.
 There are no ads or analytics trackers in this software.
 The service used to determine your public IP address is [open source](https://github.com/aaronjwood/public-ip-api) and is 100% stateless.
+
+## Acknowledgements
+
+MAC address vendor OUI resolution is possible thanks to the [lookup table](https://www.wireshark.org/download/automated/data/manuf) assembled by WireShark from IEEE public OUI listings.
+See also [Wireshark's OUI Lookup Tool](https://www.wireshark.org/tools/oui-lookup.html).
+
+Port service names and descriptions are provided by the IANA as the [Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml).

--- a/app/src/main/java/com/aaronjwood/portauthority/async/DownloadAsyncTask.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/async/DownloadAsyncTask.java
@@ -11,6 +11,7 @@ import com.aaronjwood.portauthority.response.MainAsyncResponse;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
@@ -95,7 +96,11 @@ public abstract class DownloadAsyncTask extends AsyncTask<Void, DownloadProgress
                     return;
                 }
 
-                in = new BufferedReader(new InputStreamReader(new GZIPInputStream(body.byteStream()), StandardCharsets.UTF_8));
+                InputStream bodyStream = body.byteStream();
+                if ("gzip".equals(response.header("Content-Encoding"))) {
+                    bodyStream = new GZIPInputStream(bodyStream);
+                }
+                in = new BufferedReader(new InputStreamReader(bodyStream, StandardCharsets.UTF_8));
                 String line;
                 long total = 0;
                 while ((line = in.readLine()) != null) {

--- a/app/src/main/java/com/aaronjwood/portauthority/async/DownloadOuisAsyncTask.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/async/DownloadOuisAsyncTask.java
@@ -9,8 +9,7 @@ import java.lang.ref.WeakReference;
 
 public class DownloadOuisAsyncTask extends DownloadAsyncTask {
 
-    // The official source on gitlab.com doesn't provide a content length header which ruins our ability to report progress!
-    private static final String SERVICE = "https://raw.githubusercontent.com/wireshark/wireshark/master/manuf";
+    private static final String SERVICE = "https://www.wireshark.org/download/automated/data/manuf";
 
     /**
      * Creates a new asynchronous task to handle downloading OUI data.

--- a/app/src/main/java/com/aaronjwood/portauthority/async/DownloadPortDataAsyncTask.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/async/DownloadPortDataAsyncTask.java
@@ -9,7 +9,7 @@ import java.lang.ref.WeakReference;
 public class DownloadPortDataAsyncTask extends DownloadAsyncTask {
 
     // The official source on iana.org doesn't provide a content length header which ruins our ability to report progress!
-    private static final String SERVICE = "https://raw.githubusercontent.com/wireshark/wireshark/master/services";
+    private static final String SERVICE = "https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.csv";
 
     /**
      * Creates a new asynchronous task that takes care of downloading port data.

--- a/app/src/main/java/com/aaronjwood/portauthority/parser/OuiParser.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/parser/OuiParser.java
@@ -17,12 +17,12 @@ public class OuiParser implements Parser {
         }
 
         String[] data = line.split("\\t");
-        String mac = data[0].toLowerCase();
+        String mac = data[0].trim().toLowerCase();
         String vendor;
         if (data.length == 3) {
             vendor = data[2];
         } else {
-            vendor = data[1];
+            vendor = data[1].trim();
         }
 
         return new String[]{mac, vendor};

--- a/app/src/main/java/com/aaronjwood/portauthority/parser/PortParser.java
+++ b/app/src/main/java/com/aaronjwood/portauthority/parser/PortParser.java
@@ -5,27 +5,27 @@ import com.aaronjwood.portauthority.db.Database;
 public class PortParser implements Parser {
 
     /**
-     * Parses the line of port data based on IANA's format.
+     * Parses the line of the port data CSV file provided by IANA.
      *
      * @param line
      * @return
      */
     @Override
     public String[] parseLine(String line) {
-        if (line.isEmpty() || line.startsWith("#")) {
+        if (line.isEmpty() || line.startsWith(" ") || line.startsWith(",")) {
             return null;
         }
 
-        String[] data = line.split("\\s+");
-        if (!data[1].contains("tcp")) {
+        String[] data = line.split(",");
+        if (data.length < 3 || !data[2].contains("tcp")) {
             return null;
         }
 
-        String port = data[1].substring(0, data[1].indexOf("/"));
-        String description = data[0];
-        if (line.contains("#")) {
-            description = line.substring(line.indexOf("#") + 1);
+        String port = data[1];
+        if (!port.matches("\\d+")){
+            return null;
         }
+        String description = data.length >= 4 ? data[3] : data[0];
 
         return new String[]{port, description};
     }


### PR DESCRIPTION
Fixes #155.

Wireshark removed the `manuf` and `services` files from their git repo which were used for MAC vendor/OUI resolution and port service name and description lookup, respectively. Fortunately, similar replacements are provided elsewhere.

As discussed in #155, Wireshark now hosts a generated file very similar to `manuf` at <https://www.wireshark.org/download/automated/data/manuf>.

The [`services`](https://raw.githubusercontent.com/wireshark/wireshark/v4.0.8/services) cites the IANA's [Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml) as their original source, with [permission from and acknowledgement to the IANA](https://www.wireshark.org/lists/wireshark-dev/200708/msg00160.html).

I have added acknowledgements for both sources to the readme.

Sadly, both replacements do not support `Accept-Encoding: gzip`, ~and progress tracking is somewhat broken for the OUI update (finishes when displaying \~33%) and does not work for the ports update~.
For this and other reasons, replacements hosted by GitHub or other CDNs would be preferable.